### PR TITLE
IE 106 - Patient Search does not work with pagination

### DIFF
--- a/src/reducers/patient.js
+++ b/src/reducers/patient.js
@@ -18,7 +18,8 @@ export default function(state = { patients: null,
                          meta: action.payload.data.Meta,
                          pageNum: Math.ceil(action.payload.data.Meta.total / state.patientsPerPage) };
     case SET_PATIENT_SEARCH:
-      return { ...state, patientSearch: action.payload };
+      // We want to reset the page to 1 so the search results are shown.
+      return { ...state, patientSearch: action.payload, currentPage: 1 };
     case SELECT_PAGE:
       return { ...state, currentPage: action.payload };
     case FETCH_PATIENT_FULFILLED:

--- a/test/reducers/patient_test.js
+++ b/test/reducers/patient_test.js
@@ -1,0 +1,18 @@
+import { expect, renderComponent } from '../test_helper';
+import patient from '../../src/reducers/patient';
+import {
+  FETCH_PATIENTS_FULFILLED,
+  SET_PATIENT_SEARCH,
+  SELECT_PAGE,
+  FETCH_PATIENT_FULFILLED
+} from '../../src/actions/types';
+
+describe('Patient Reducer', () => {
+
+  it('When changing the patient search the correct page is set', () => {
+    const state = {};
+    const newState = patient(state, {payload: '', type:SET_PATIENT_SEARCH});
+    expect(newState.currentPage).to.equal(1);
+    expect(newState.patientSearch).to.equal('');
+  });
+});


### PR DESCRIPTION
Resolved issue by setting currentPage to 1 when we change search terms. 

Added tests to avoid any regression. 